### PR TITLE
Move phpunit require to require-dev.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,10 @@
     "verifymy/php-sdk": "^v1.0.0",
     "verifymycontent/commons": "^v1.0.2",
     "ext-json": "*",
-    "phpunit/phpunit": "^9.5",
     "php": "^7.4|^8.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9.5"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This moves the phpunit require to require-dev as it should not be a requirement to have phpunit unless you are developing.